### PR TITLE
deploy: always sign with PRIVATE_KEY (never PRIVATE_KEY_DEV)

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Per project policy, deploy workflows must always sign with `secrets.PRIVATE_KEY`. Replaces the `github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV` conditional in: rainix.yaml