### PR TITLE
ci: adopt rainix nix-cachix-setup composite, drop deprecated DeterminateSystems nix installer

### DIFF
--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -17,8 +17,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix develop -c rainix-sol-prelude
       - name: Run ${{ matrix.task }}


### PR DESCRIPTION
Closes #10

## What

Replace the two deprecated **DeterminateSystems** CI steps in `.github/workflows/rainix.yaml` with the org-standard shared composite:

- `DeterminateSystems/nix-installer-action@v4` → gone
- `DeterminateSystems/magic-nix-cache-action@v2` → gone
- both replaced by `rainlanguage/rainix/.github/actions/nix-cachix-setup@main` (nix-quick-install + Cachix substituter + `cache-nix-action` store restore/save, every third-party action SHA-pinned in one place).

`checkout: 'false'` is passed because this job needs the existing `actions/checkout@v4` with `submodules: recursive` + `fetch-depth: 0` (the sol prelude and fork tests need submodules), which the composite's bundled default checkout would not replicate. The composite runs after the repo's own checkout.

This is the **Preferred** fix the issue calls for (adopt the shared composite where the workflow shape allows) and also retires a *second* deprecated DeterminateSystems action (`magic-nix-cache`) in the same change. `nix-installer-action` was pinned `@v4` (a fixed version but a deprecated action); the composite SHA-pins nix-quick-install-action.

## QA evidence (QA-GUIDE §8)

- **Category:** CI-config change (a GitHub Actions workflow YAML). There is **no executable code logic** in the diff, so there is no unit under test and nothing to mutation-test — the adversarial-mutation lens is N/A for this category (per the guide, docs/CI fixes are verified end-to-end, not by mutation).
- **Oracle / discriminating check:** the workflow itself is the test. `rainix.yaml` runs `on: [push]`, so pushing this branch triggers the **full sol matrix** — `rainix-sol-test`, `rainix-sol-static`, `rainix-sol-legal` — each executed via `nix develop -c …`. If the installer/cache swap failed to make `nix` available (or broke the store/cache), every one of those `nix develop` steps would fail. A green matrix on this PR is therefore direct end-to-end proof the new nix setup works; a broken swap fails closed.
- **Fail-on-base confidence:** `main` is currently green on all three matrix tasks with the old DeterminateSystems steps; this PR's CI re-runs the identical task set with only the nix-setup steps changed, isolating the swap.
- **Interface correctness:** the composite is used per its documented inputs (`checkout`, `cachix-auth-token`); `checkout: 'false'` verified against the composite's `action.yml` (its bundled checkout is gated on `inputs.checkout == 'true'`). YAML validated (`yq` parse).
- **Scope:** one file, +4/−2, no source or test changes; deterministic and reversible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration setup for Nix installation and caching.
  * Streamlined cache configuration using the repository’s shared setup action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->